### PR TITLE
extract WKT string from laz vlrs

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -7,7 +7,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -21,6 +24,7 @@ using DragDropEffects = System.Windows.DragDropEffects;
 using DragEventArgs = System.Windows.DragEventArgs;
 using OpenFileDialog = Microsoft.Win32.OpenFileDialog;
 using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
+using Newtonsoft.Json;
 
 namespace PointCloudConverter
 {
@@ -186,7 +190,7 @@ namespace PointCloudConverter
                         errorCounter++;
                         if (importSettings.useJSONLog)
                         {
-                            Log.WriteLine("{\"event\": \"" + LogEvent.File + "\", \"path\": " + JsonSerializer.Serialize(importSettings.inputFiles[i]) + ", \"status\": \"" + LogStatus.Processing + "\"}", LogEvent.Error);
+                            Log.WriteLine("{\"event\": \"" + LogEvent.File + "\", \"path\": " + System.Text.Json.JsonSerializer.Serialize(importSettings.inputFiles[i]) + ", \"status\": \"" + LogStatus.Processing + "\"}", LogEvent.Error);
                         }
                         else
                         {
@@ -228,7 +232,7 @@ namespace PointCloudConverter
                     errorCounter++;
                     if (importSettings.useJSONLog)
                     {
-                        Log.WriteLine("{\"event\": \"" + LogEvent.File + "\", \"path\": " + JsonSerializer.Serialize(importSettings.inputFiles[i]) + ", \"status\": \"" + LogStatus.Processing + "\"}", LogEvent.Error);
+                        Log.WriteLine("{\"event\": \"" + LogEvent.File + "\", \"path\": " + System.Text.Json.JsonSerializer.Serialize(importSettings.inputFiles[i]) + ", \"status\": \"" + LogStatus.Processing + "\"}", LogEvent.Error);
                     }
                     else
                     {
@@ -387,7 +391,7 @@ namespace PointCloudConverter
 
                 string jsonString = "{" +
                 "\"event\": \"" + LogEvent.File + "\"," +
-                "\"path\": " + JsonSerializer.Serialize(importSettings.inputFiles[fileIndex]) + "," +
+                "\"path\": " + System.Text.Json.JsonSerializer.Serialize(importSettings.inputFiles[fileIndex]) + "," +
                 "\"size\": " + new FileInfo(importSettings.inputFiles[fileIndex]).Length + "," +
                 "\"points\": " + pointCount + "," +
                 "\"status\": \"" + LogStatus.Processing + "\"" +
@@ -474,7 +478,14 @@ namespace PointCloudConverter
             // if this was last file
             if (fileIndex == (importSettings.maxFiles - 1))
             {
-                var jsonMeta = JsonSerializer.Serialize(lasHeaders, new JsonSerializerOptions() { WriteIndented = true });
+                JsonSerializerSettings settings = new JsonSerializerSettings
+                {
+                    StringEscapeHandling = StringEscapeHandling.Default // This prevents escaping of characters and write the WKT string properly
+                };
+
+                string jsonMeta = JsonConvert.SerializeObject(lasHeaders, settings);
+
+                // var jsonMeta = JsonSerializer.Serialize(lasHeaders, new JsonSerializerOptions() { WriteIndented = true });
                 //Log.WriteLine("MetaData: " + jsonMeta);
                 // write metadata to file
                 var jsonFile = Path.Combine(Path.GetDirectoryName(importSettings.outputFile), Path.GetFileNameWithoutExtension(importSettings.outputFile) + ".json");

--- a/PointCloudConverter.csproj
+++ b/PointCloudConverter.csproj
@@ -47,6 +47,9 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>

--- a/Readers/LAZ.cs
+++ b/Readers/LAZ.cs
@@ -13,6 +13,7 @@ using LASzip.Net;
 using System.IO;
 using PointCloudConverter.Structs.VariableLengthRecords;
 using Free.Ports.LibGeoTiff;
+using System.Text;
 
 namespace PointCloudConverter.Readers
 {
@@ -88,6 +89,14 @@ namespace PointCloudConverter.Readers
                     vlr.RecordLengthAfterHeader = lazReader.header.vlrs[i].record_length_after_header;
                     vlr.Description = System.Text.Encoding.UTF8.GetString(lazReader.header.vlrs[i].description);
                     vlr.Description = vlr.Description.Replace("\0", string.Empty);
+
+                    //Get WKT (Well Known Text String)
+                    if (vlr.RecordID == 2112)
+                    {
+                        string wkt = Encoding.ASCII.GetString(lazReader.header.vlrs[i].data);
+                        Console.WriteLine("WKT string = " + wkt);
+                        h.WKT = wkt;
+                    }
 
                     // get GeoKeyDirectoryTag
                     if (vlr.RecordID == 34735)

--- a/Structs/Metadata/LasHeader.cs
+++ b/Structs/Metadata/LasHeader.cs
@@ -9,7 +9,8 @@ namespace PointCloudConverter.Structs
         public string FileName { get; set; }
         // v1.2
         public ushort ProjectionID { get; set; } // these are duplicate data from the VLR (just for convenience)
-        public string Projection { get; set; } 
+        public string Projection { get; set; }
+        public string WKT { get; set; }
 
         public ushort FileSourceID { get; set; }
         public ushort GlobalEncoding { get; set; }

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />


### PR DESCRIPTION
- extract WKT (Well known text string) from laz vlrs, if available
- store it in the header as WKT string
- change encoding of the _metadata json_ to newtonsoft to better format the string.

Note:
With the previous serializing of the metatdata json, the WKT string would end up with many "\\u0022" characters written in it.
I seem to have corrected that out by importing and using newtonsoft json for serializing but perhaps there is a better way?



Here is an example of a WKT that may or may not be in a laz file, and may or may not be stored in the **_vlr.RecordID 2112_**
I can email a sample laz file containing the data for testing.

`COMPD_CS["NAD83(2011) / UTM zone 15N / Geoid2018",PROJCS["NAD83(2011) / UTM zone 15N / Geoid2018",GEOGCS["NAD83(2011) / UTM zone 15N / Geoid2018",DATUM["NAD83(2011)",SPHEROID["GRS 1980",6378137.000,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","1116"]],PRIMEM["Greenwich",0.0000000000000000,AUTHORITY["EPSG","8901"]],UNIT["Degree",0.01745329251994329547,AUTHORITY["EPSG","9102"]],AUTHORITY["EPSG","6344"]],PROJECTION["Transverse_Mercator",AUTHORITY["EPSG","9807"]],PARAMETER["latitude_of_origin",0.0000000000000000],PARAMETER["central_meridian",-93.0000000000000142],PARAMETER["scale_factor",0.9996000000000000],PARAMETER["false_easting",500000.000],PARAMETER["false_northing",0.000],UNIT["Meter",1.00000000000000000000,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","6344"]],VERT_CS["Orthometric Heights",VERT_DATUM["Geoid2018",2005,AUTHORITY["EPSG","0"]],UNIT["Meter",1.00000000000000000000,AUTHORITY["EPSG","9001"]],AXIS["Height",UP]]]`